### PR TITLE
Allow skipping sending access_log event to the webmachine_log_event

### DIFF
--- a/include/webmachine_logger.hrl
+++ b/include/webmachine_logger.hrl
@@ -15,3 +15,4 @@
 -type wm_log_data() :: #wm_log_data{}.
 
 -define(EVENT_LOGGER, webmachine_log_event).
+-define(EVENT_LOGGER_ACCESS, 'webmachine_log_access').

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -102,7 +102,8 @@ finish_response({Code, _}=CodeAndPhrase, Resource, EndTime) ->
     LogData = LogData0#wm_log_data{resource_module=RMod,
                                    end_time=EndTime,
                                    notes=Notes},
-    spawn(fun() -> do_log(LogData) end),
+    webmachine_log:log_access(LogData),
+
     webmachine_resource:stop(Resource).
 
 error_response(Reason) ->
@@ -153,9 +154,6 @@ decision_flow(X, TestResult) when is_integer(X) ->
        true -> respond(X)
     end;
 decision_flow(X, _TestResult) when is_atom(X) -> d(X).
-
-do_log(LogData) ->
-    webmachine_log:log_access(LogData).
 
 log_decision(DecisionID) ->
     Resource = get(resource),

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -188,7 +188,7 @@ handle_error(Code, Error, Req) ->
     {ok,Req2} = webmachine_request:append_to_response_body(ErrorHTML, Req1),
     {ok,Req3} = webmachine_request:send_response(Code, Req2),
     {LogData,_ReqState4} = webmachine_request:log_data(Req3),
-    spawn(webmachine_log, log_access, [LogData]),
+    webmachine_log:log_access(LogData),
     ok.
 
 get_wm_option(OptName, {WMOptions, OtherOptions}) ->

--- a/src/webmachine_sup.erl
+++ b/src/webmachine_sup.erl
@@ -59,6 +59,9 @@ init([]) ->
         {webmachine_router,
          {webmachine_router, start_link, []},
          permanent, 5000, worker, [webmachine_router]},
+
+    webmachine_log:set_custom_log_access(default),
+
     LogHandler =
         [{webmachine_logger,
           {gen_event, start_link, [{local, ?EVENT_LOGGER}]},


### PR DESCRIPTION
it does a double copy and does not scale well under heavy load